### PR TITLE
Update commands for all users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Quickstart
 
 .. code:: sh
 
-    git clone git@github.com:enqack/arbit.git
+    git clone https://github.com/enqack/arbit.git
     cd arbit
 
 Ubuntu prerequisites
@@ -37,7 +37,7 @@ Configure a python virtual environment for the bot as follows.
 
     python3.7 -m venv .venv
     . .venv/bin/activate
-    pip install -r requirements.txt
+    pip3 install -r requirements.txt
 
 Set environment variables by first copying the example file.
 


### PR DESCRIPTION
Users receive a publickey error when attempting to git clone from git:xxxxxx
Solution: use git clone https://github.com/xxxxx

Using pip installs packages for python2, so using pip3 is required.

Cool project :)